### PR TITLE
Improve Task Status Update Code Quality in TaskManager

### DIFF
--- a/src/main/java/bryan/taskmanager/TaskManager.java
+++ b/src/main/java/bryan/taskmanager/TaskManager.java
@@ -60,6 +60,7 @@ public class TaskManager {
      * @throws BryanException if the input does not specify a valid task.
      */
     private Tasks createTask(final String input) throws BryanException {
+        assert input != null && !input.isEmpty() : "Input to createTask() should not be null or empty";
         if (input.startsWith("todo ")) {
             return createTodo(input);
         }
@@ -157,7 +158,7 @@ public class TaskManager {
     public String markTask(final int index) {
         validateIndex(index);
         tasks.get(index).taskDone();
-        return "Marked task " + (index + 1) + " as done:\n  " + tasks.get(index).toString();
+        return formatStatusChangeMessage(index, tasks.get(index), true);
     }
 
     /**
@@ -169,7 +170,7 @@ public class TaskManager {
     public String unmarkTask(final int index) {
         validateIndex(index);
         tasks.get(index).taskNotDone();
-        return "Marked task " + (index + 1) + " as not done:\n  " + tasks.get(index).toString();
+        return formatStatusChangeMessage(index, tasks.get(index), false);
     }
 
     /**
@@ -203,9 +204,23 @@ public class TaskManager {
      * @throws IllegalArgumentException if the index is invalid.
      */
     private void validateIndex(final int index) {
+        assert index >= 0 && index < tasks.size() : "Index out of bounds: " + index;
         if (index < 0 || index >= tasks.size()) {
             throw new IllegalArgumentException("Invalid task number");
         }
+    }
+
+    /**
+     * Formats a status change message for a task.
+     *
+     * @param index  the zero-based index of the task in the task list
+     * @param task   the task whose status was updated
+     * @param marked {@code true} if the task is marked as done, {@code false} if unmarked
+     * @return a formatted string message indicating the updated status of the task
+     */
+    private String formatStatusChangeMessage(final int index, final Tasks task, final boolean marked) {
+        String status = marked ? "done" : "not done";
+        return "Marked task " + (index + 1) + " as " + status + ":\n  " + task.toString();
     }
 
     /**


### PR DESCRIPTION
The previous TaskManager.markTask() and unmarkTask() methods duplicate logic for formatting status change messages, making the code harder to maintain and read. This duplication risks inconsistencies if changes aren’t applied to both methods.

This PR extracts the formatting logic into a new helper method, formatStatusChangeMessage, and updates markTask() and unmarkTask() to use it. This approach eliminates duplication and improves readability by centralizing the formatting responsibility, following code quality principles like reusability and separation of concerns.

No functional changes are introduced—task marking behavior remains the same. I tested this by manually marking and unmarking tasks to verify consistent status messages. 